### PR TITLE
Fix params.pp parsing for OpenBSD:

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class openvpn::params {
       $manage_service = false
       $openvpn_user   = '_openvpn'
       $openvpn_group  = '_openvpn'
-      if ( $::operatingsystemrelease < 5.7 ) {
+      if ( versioncmp($::kernelversion, '5.7') < 0 ) {
         $openssl = '/usr/sbin/openssl'
       } else {
         $openssl ='/usr/bin/openssl'


### PR DESCRIPTION
Prevent error like:
Comparison of: String < Float, is not possible. Caused by 'A string
is not comparable to a non String'. at ... openvpn/manifests/params.pp:22:38

This is with Puppet 3.8.2 and future parser.

I use versioncmp against ::kernelversion, since ::operatingsystemrelease might
be suffixed with -snapshot, -stable, etc.
That ::kernelversion I also use in other modules, i.e. acidprime/r10k.