### PR TITLE
Fix notification of service on config changes

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -72,7 +72,7 @@ class openvpn::server (
     }
   }
 
-  if $openvpn::params::manage_service {
+  if $openvpn::manage_service {
     Exec["create ${dh}"] ~>
     Service['openvpn']
 


### PR DESCRIPTION
The IPv6 support broke the notification for cases where the default is
not to manage the service but service management is explicitly enabled
as a paramter to the openvpn class.