### PR TITLE
Make the compression and ns-cert-type parameters optional in client configurations

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -14,6 +14,7 @@ define openvpn::client (
   $ns_cert_type   = 'server',
   $verb           = 3,
   $cipher         = 'AES-192-CBC',
+  $compression    = 'lzo',
   $openvpn_group  = $openvpn::params::openvpn_group,
   $openvpn_user   = $openvpn::params::openvpn_user,
   $tls_auth_key   = undef,

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -21,9 +21,13 @@ user  <%= @openvpn_user %>
 <% if @openvpn_group -%>
 group <%= @openvpn_group %>
 <% end -%>
+<% if @ns_cert_type -%>
 ns-cert-type <%= @ns_cert_type %>
+<% end -%>
 cipher <%= @cipher %>
-comp-lzo
+<% if @compression -%>
+comp-<%= @compression %>
+<% end -%>
 verb <%= @verb %>
 # custom options
 <% @custom_options.each do |custom_option| -%>


### PR DESCRIPTION
By default it will behave as before, but if you need to not have these options set, passing 'false' will not set them in the config file