### PR TITLE
Start SystemD unit for client connections on Xenial and Jessie

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -33,5 +33,16 @@ define openvpn::client (
   if $openvpn::params::manage_service {
     File["${openvpn_dir}/${server}.conf"] ~>
     Service['openvpn']
+
+    if $openvpn::params::manage_systemd_unit {
+      service { "openvpn@${server}":
+        ensure  => running,
+        enable  => true,
+        require => File[$openvpn_dir],
+      }
+
+      File["${openvpn_dir}/${server}.conf"] ~>
+      Service["openvpn@${server}"]
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,5 +35,17 @@ class openvpn::params {
     }
   }
 
+  case $::lsbdistcodename {
+    'xenial', 'jessie': {
+      # On Ubuntu Xenial and Debian Jessie, starting the 'openvpn' service doesn't connect a client
+      # the 'openvpn@<connection name>' service needs to be started, where <connection name> is
+      # the name of the config file in /etc/openvpn, minus the .conf extension.
+      $manage_systemd_unit = true
+    }
+    default: {
+      $manage_systemd_unit = false
+    }
+  }
+
   $ccd = 'ccd'
 }


### PR DESCRIPTION
On Ubuntu Xenial and Debian Jessie, starting the `openvpn` service
doesn't connect a client the `openvpn@<connection name>` service
needs to be started, where <connection name> is the name of the config
file in `/etc/openvpn`, minus the `.conf` extension.

I have not tested that this works on Jessie, but the package seems
to share the same form as the one on Xenial. This fix may be applicable
for other platforms.

Fixes #35
