### PR TITLE
fix client user/group parameter defaults

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -15,13 +15,25 @@ define openvpn::client (
   $verb           = 3,
   $cipher         = 'AES-192-CBC',
   $compression    = 'lzo',
-  $openvpn_group  = $openvpn::params::openvpn_group,
-  $openvpn_user   = $openvpn::params::openvpn_user,
+  $openvpn_group  = '',
+  $openvpn_user   = '',
   $tls_auth_key   = undef,
   $custom_options = [],
 ) {
 
   include openvpn
+
+  if $openvpn_group != '' {
+    $_openvpn_group = $openvpn_group
+  } else {
+    $_openvpn_group = $openvpn::params::openvpn_group
+  }
+
+  if $openvpn_user != '' {
+    $_openvpn_user = $openvpn_user
+  } else {
+    $_openvpn_user = $openvpn::params::openvpn_user
+  }
 
   file { "${openvpn_dir}/${server}.conf":
     owner   => root,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,14 @@ class openvpn::params {
         $openssl ='/usr/bin/openssl'
       }
     }
+    'Debian','Ubuntu': {
+      $openvpn_dir    = '/etc/openvpn'
+      $package_name   = 'openvpn'
+      $manage_service = true
+      $openvpn_user   = 'nobody'
+      $openvpn_group  = 'nogroup'
+      $openssl        = '/usr/bin/openssl'
+    }
     default: {
       $openvpn_dir    = '/etc/openvpn'
       $package_name   = 'openvpn'

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -15,11 +15,11 @@ tls-auth <%= @tls_auth_key %> 1
 <% if @auth -%>
 auth <%= @auth %>
 <% end -%>
-<% if @openvpn_user -%>
-user  <%= @openvpn_user %>
+<% if @_openvpn_user -%>
+user  <%= @_openvpn_user %>
 <% end -%>
-<% if @openvpn_group -%>
-group <%= @openvpn_group %>
+<% if @_openvpn_group -%>
+group <%= @_openvpn_group %>
 <% end -%>
 <% if @ns_cert_type -%>
 ns-cert-type <%= @ns_cert_type %>


### PR DESCRIPTION
defines have no inheritance. we need to workaround
that the defaults are taken.

Also fix default group for Ubuntu/Debian (nobody is
not available as group)