### PR TITLE
avoid Unknown variable messages in master log

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,13 @@ class openvpn::params {
     }
   }
 
-  case $::lsbdistcodename {
+  if defined('$::lsbdistcodename') {
+    $_dist_code = $::lsbdistcodename
+  } else {
+    $_dist_code = 'default'
+  }
+
+  case $_dist_code {
     'xenial', 'jessie': {
       # On Ubuntu Xenial and Debian Jessie, starting the 'openvpn' service doesn't connect a client
       # the 'openvpn@<connection name>' service needs to be started, where <connection name> is


### PR DESCRIPTION
$::lsbdistcodename is not available on all operatingsystems
if not available (eg. on OpenBSD) an error on masters log
is written ("Unknown variable: '::lsbdistcodename'. at).