### PR TITLE
route push require quotes

### DIFF
--- a/templates/server.conf.erb
+++ b/templates/server.conf.erb
@@ -39,7 +39,7 @@ crl-verify <%= @crl %>
 # address pool (10.8.0.0/255.255.255.0)
 # back to the OpenVPN server.
 <% Array(@route).each do |r| -%>
-push route <%= r %>
+push "route <%= r %>"
 <% end -%>
 
 <% Array(@route_ipv6).each do |r| -%>


### PR DESCRIPTION
Official examples: https://secure-computing.net/wiki/index.php/OpenVPN/Routing
Without qutes, puppet-openvpn configs like
```
     route  => [
      "192.168.188.0 255.255.255.0",
    ],
```
generate:
  `push route 192.168.188.0 255.255.255.0`

which leads to an error:
  Options error: Unrecognized option or missing or
  extra parameter(s) in /usr/local/etc/openvpn/openvpn.conf:25: push (2.4.6)

OpenVPN version: openvpn-**2.4.6**