### PR TITLE
Dev dh options

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -61,10 +61,14 @@ class openvpn::server (
     content => template('openvpn/server.conf.erb'),
   }
 
+  $fq_dh = $dh ? {
+      /^\/.*/ => $dh,
+      default => "${openvpn_dir}/${dh}",
+  }
   exec { "create ${dh}":
     cwd     => $openvpn_dir,
-    command => "${openssl} dhparam -out ${dh} 2048",
-    creates => "${openvpn_dir}/${dh}",
+    command => "${openssl} dhparam -out ${fq_dh} 2048",
+    creates => $fq_dh,
   }
 
   if $tls_auth {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -13,6 +13,7 @@ class openvpn::server (
   $dev                      = 'tun',
   $dev_type                 = '',
   $dh                       = 'dh2048.pem',
+  $dh_size                  = 2048,
   $dns                      = '',
   $domain                   = '',
   $wins                     = '',
@@ -67,7 +68,7 @@ class openvpn::server (
   }
   exec { "create ${dh}":
     cwd     => $openvpn_dir,
-    command => "${openssl} dhparam -out ${fq_dh} 2048",
+    command => "${openssl} dhparam -out ${fq_dh} ${dh_size}",
     creates => $fq_dh,
   }
 


### PR DESCRIPTION
I need to use a fully qualified path for dh (and also for all the other file references like keys and certs), to start the openvpn server in the OpenBSD /etc/hostname.* files. This allows to set rdomain and lets you do firewalling on the tun device better.

For other parmeters fully qualified file reference are working (for ta.key, you have to use the custom_options).