### PR TITLE
add parameter for setup of compression

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -40,6 +40,7 @@ class openvpn::server (
   $topology                 = 'subnet',
   $custom_options           = [],
   $ccd                      = 'ccd',
+  $compress                 = 'legacy',
 ) {
 
   include openvpn

--- a/templates/server.conf.erb
+++ b/templates/server.conf.erb
@@ -208,7 +208,13 @@ cipher <%= @cipher %>
 # Enable compression on the VPN link.
 # If you enable it here, you must also
 # enable it in the client config file.
-comp-lzo
+<% if @compress!='' -%>
+  <%- if @compress == 'legacy' -%>
+    <%- %>comp-lzo
+  <%- else -%>
+    <%- %>compress <%= @compress %>
+  <%- end -%>
+<% end -%>
 
 # The maximum number of concurrently connected
 # clients we want to allow.


### PR DESCRIPTION
in openvpn 2.4 a new parameter 'compress' was introduces.
To use the deprecated comp-lzo setting, set the compress
parameter to 'legacy' (this is the default). To disable
compression, set to ''.