### PR TITLE
Fix fully qualified path for openvpn in exec

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,6 @@
 ---
 openvpn::openvpn_dir: '/etc/openvpn'
+openvpn::openvpn_path: '/usr/sbin/openvpn'
 openvpn::package_name: 'openvpn'
 openvpn::manage_service: true
 openvpn::openvpn_user: 'nobody'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 class openvpn (
   String $openvpn_dir,
-  String $openvpn_path,
+  Stdlib::Absolutepath $openvpn_path,
   String $package_name,
   Boolean $manage_service,
   Boolean $manage_systemd_unit,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@
 #
 class openvpn (
   String $openvpn_dir,
+  String $openvpn_path,
   String $package_name,
   Boolean $manage_service,
   Boolean $manage_systemd_unit,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -49,6 +49,7 @@ class openvpn::server (
 
   include openvpn
   $openvpn_dir   = $openvpn::openvpn_dir
+  $openvpn_path  = $openvpn::openvpn_path
   $openvpn_group = $openvpn::openvpn_group
   $openvpn_user  = $openvpn::openvpn_user
   $openssl       = $openvpn::openssl
@@ -92,7 +93,7 @@ class openvpn::server (
   if $tls_auth {
     exec { 'create tls_auth key':
       cwd     => $openvpn_dir,
-      command => 'openvpn --genkey --secret ta.key',
+      command => "${openvpn_path} --genkey --secret ta.key",
       creates => "${openvpn_dir}/ta.key",
     }
   }


### PR DESCRIPTION
The current code fails on Puppet 6 with:

```
Error: Validation of Exec[create tls_auth key] failed: 'openvpn' is not qualified and no path was specified. Please qualify the command or specify a path. (file: /etc/puppetlabs/code/environments/production/modules/openvpn/manifests/server.pp, line: 71)
```

This PR resolves the above error.